### PR TITLE
fix/mypage,detail,profilepage:

### DIFF
--- a/src/components/detail/PostInfo/NavBar.tsx
+++ b/src/components/detail/PostInfo/NavBar.tsx
@@ -62,6 +62,7 @@ const NavContainer = styled.div`
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   margin-bottom: 60px;
+  margin-top: 80px;
   background-color: ${(props) => props.theme.colors.white};
 `;
 

--- a/src/components/userProfile/UserOnSale.tsx
+++ b/src/components/userProfile/UserOnSale.tsx
@@ -3,8 +3,11 @@ import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
 import { userPostsAtom } from '../../atom';
 import ReactPaginate from 'react-paginate';
+import { useNavigate } from 'react-router-dom';
+import { postType } from '../../types';
 
 const UserOnSale = () => {
+  const navigate = useNavigate();
   const userPosts = useRecoilValue(userPostsAtom);
   const [currentPage, setCurrentPage] = useState(0);
   const itemsPerPage = 8;
@@ -16,13 +19,17 @@ const UserOnSale = () => {
     const endIndex = startIndex + itemsPerPage;
     return userPosts?.slice(startIndex, endIndex);
   }, [currentPage, userPosts]);
+
+  const onClickMoveDetail = (post:postType) => {
+    navigate(`/detail/${post.category}/${post.id}`)
+  }
   return (
     <>
       <Title>판매상품 ({userPosts && userPosts.length})</Title>
       <PostsContainer>
         {currentPagePosts?.map((post) => {
           return (
-            <PostContainer key={post.id}>
+            <PostContainer key={post.id} onClick={()=>onClickMoveDetail(post)}>
               {post.isDone && <ClearPost>거래완료</ClearPost>}
               <PostIMG bgPhoto={post.imgURL} />
               <ContentsContainer>
@@ -131,7 +138,7 @@ const ClearPost = styled.div`
   top: 0;
   left: 0;
   width: 282px;
-  height: 347px;
+  height: 355px;
   background-color: rgba(0, 0, 0, 0.5);
   z-index: 2;
   font-size: ${(props) => props.theme.fontSize.title32};
@@ -139,7 +146,7 @@ const ClearPost = styled.div`
   line-height: ${(props) => props.theme.lineHeight.title32};
   color: ${(props) => props.theme.colors.orange01};
   text-align: center;
-  line-height: 347px;
+  line-height: 355px;
 `;
 
 const PaginationContainer = styled.div`

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -18,6 +18,7 @@ import {
 } from '../api';
 import {
   customConfirm,
+  customInfoAlert,
   customSuccessAlert,
 } from '../components/modal/CustomAlert';
 import Loader from '../components/etc/Loader';
@@ -70,6 +71,15 @@ const MyPage = () => {
     return post.isDone === true;
   });
 
+   const isDoneSell = tradeSellData?.filter((post: any) => {
+     return post.isDone === false;
+   });
+  
+  
+  const isDoneBuy = tradeBuyData?.filter((post:any) => {
+    return post.isDone === false;
+  })
+
   /*회원탈퇴 */
   const user = auth.currentUser;
   const { mutate: deletedUser } = useMutation(
@@ -94,14 +104,18 @@ const MyPage = () => {
   );
   // deleteUsers
   const deleteAuth = () => {
-    customConfirm(
-      '탈퇴 하시겠습니까?',
-      '탈퇴 시 모든 정보는 삭제가 됩니다.\n정말 탈퇴하시겠습니까?',
-      '회원 탈퇴',
-      async () => {
-        await deletedUser(id);
-      }
-    );
+    if (isDoneBuy?.[0] || isDoneSell?.[0]) {
+      customInfoAlert('매칭중인 회원은 탈퇴가 불가능합니다.');
+    } else {
+      customConfirm(
+        '탈퇴 하시겠습니까?',
+        '탈퇴 시 모든 정보는 삭제가 됩니다.\n정말 탈퇴하시겠습니까?',
+        '회원 탈퇴',
+        async () => {
+          await deletedUser(id);
+        }
+      );
+    }
   };
 
   /* 1. 관심목록에서 포스트 클릭 시 조회수 + 1 후 해당 페이지로 이동합니다.


### PR DESCRIPTION


## What is this PR? 🔍

- 회원탈퇴 시 거래중인 글 있으면 탈퇴를 못합니다.
- 거래완료,판매중 버튼과 navbar 간격이 띄워서 보여집니다.
- 프로필페이지에서 포스트를 클릭하면 해당 포스트의 디테일 페이지로 이동됩니다.
## branch

- fix/mypage,detail,profilepage -> dev

## Changes 📝

- mypage: 회원탈퇴 시 거래중인 글 있으면 탈퇴 못하게 예외처리 진행했습니다.
- detail: 판매중 거래완료 버튼이 navbar에 너무 붙어있어서 ui 수정했습니다.
- profilepage: 포스트 클릭해서 해당 포스트의 디테일페이지를 볼 수 있게 하였습니다.

#181 

by @km-young 
